### PR TITLE
feat: change if-else statment to php 8 match method

### DIFF
--- a/src/WebPConverter.php
+++ b/src/WebPConverter.php
@@ -16,17 +16,13 @@ class WebPConverter
      */
     private static function createImageResource(string $path, string $extension): GdImage
     {
-        if ($extension === 'png') {
-            $imageResource = imagecreatefrompng($path);
-        } elseif ($extension === 'jpeg' || $extension === 'jpg') {
-            $imageResource = imagecreatefromjpeg($path);
-        } elseif ($extension === 'bmp') {
-            $imageResource = imagecreatefrombmp($path);
-        } elseif ($extension === 'gif') {
-            $imageResource = imagecreatefromgif($path);
-        } else {
-            throw new Exception("No valid file type provided for {$path}");
-        }
+        $imageResource = match ($extension) {
+            'jpeg', 'jpg' => imagecreatefromjpeg($path),
+            'png' => imagecreatefrompng($path),
+            'bmp' => imagecreatefrombmp($path),
+            'gif' => imagecreatefromgif($path),
+            default => throw new Exception("No valid file type provided for {$path}"),
+        };
         self::setColorsAndAlpha($imageResource);
         return $imageResource;
     }


### PR DESCRIPTION
Convert the if / elseif / elseif check to a match method.

https://www.php.net/manual/fr/control-structures.match.php

Advantages : 
1. Keeps the strict equality comparisons 
2. Only one return value to handle
3. Remove necessity for terminating statment (else / break)
4. Feels overall cleaner/sexier 
